### PR TITLE
🐛: bugfix 아티클 조회시 출석 존재하지 않을때 예외처리 되는 문제 해결 #58

### DIFF
--- a/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/ArticleRetrieveService.java
+++ b/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/ArticleRetrieveService.java
@@ -72,6 +72,7 @@ public class ArticleRetrieveService {
 
 	}
 
+	@Transactional
 	public ArticleDetailResponse findArticleDetail(Long memberId, Long articleId) {
 		Article article = ArticleServiceUtils.findArticleById(articleRepository, articleId);
 		Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);

--- a/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/challenge/ChallengeService.java
+++ b/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/challenge/ChallengeService.java
@@ -1,21 +1,16 @@
 package com.chiwawa.lionheart.api.service.challenge;
 
-import static com.chiwawa.lionheart.common.constant.message.AttendanceErrorMessage.*;
-
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.chiwawa.lionheart.common.exception.ErrorCode;
-import com.chiwawa.lionheart.common.exception.model.NotFoundException;
 import com.chiwawa.lionheart.common.util.DateUtils;
-import com.chiwawa.lionheart.common.util.MessageUtils;
 import com.chiwawa.lionheart.domain.domain.challenge.Attendance;
 import com.chiwawa.lionheart.domain.domain.challenge.repository.AttendanceRepository;
-import com.chiwawa.lionheart.domain.domain.challenge.repository.ChallengeRepository;
 import com.chiwawa.lionheart.domain.domain.member.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -24,30 +19,24 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 public class ChallengeService {
-	private final ChallengeRepository challengeRepository;
 	private final AttendanceRepository attendanceRepository;
 
-	private final static int ATTENDANCE = 0;
-
 	public void checkAttendance(Member member) {
-		if (compareLastAttendanceDate(member) != ATTENDANCE) {
-			challengeRepository.checkAttendance(member);
+		if (notAttended(member)) {
+			attendanceRepository.save(Attendance.newInstance(member));
 		}
 	}
 
-	private int compareLastAttendanceDate(Member member) {
-		Attendance firstMemberAttendance = findMemberLastAttendance(member);
-
-		return DateUtils.getDayDifference(LocalDateTime.now(), firstMemberAttendance.getCreatedAt());
+	private boolean notAttended(Member member) {
+		Optional<Attendance> firstMemberAttendance = findMemberLastAttendance(member);
+		if (firstMemberAttendance.isEmpty()) {
+			return true;
+		}
+		return DateUtils.getDayDifference(LocalDateTime.now(), firstMemberAttendance.get().getCreatedAt()) != 0;
 	}
 
-	private Attendance findMemberLastAttendance(Member member) {
+	private Optional<Attendance> findMemberLastAttendance(Member member) {
 		List<Attendance> memberAttendances = attendanceRepository.findAttendancesByMember(member);
-
-		return memberAttendances.stream().max(Comparator.comparing(Attendance::getCreatedAt))
-			.orElseThrow(() ->
-				new NotFoundException(
-					MessageUtils.generate(NOT_EXIST_MEMBER_ATTENDANCE_DATA_ERROR_MESSAGE, member.getId()),
-					ErrorCode.NOT_FOUND_MEMBER_ATTENDANCE_DATA_EXCEPTION));
+		return memberAttendances.stream().max(Comparator.comparing(Attendance::getCreatedAt));
 	}
 }

--- a/lionheart-api/src/main/resources/application-local.yml
+++ b/lionheart-api/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
 

--- a/lionheart-common/src/main/java/com/chiwawa/lionheart/common/constant/message/AttendanceErrorMessage.java
+++ b/lionheart-common/src/main/java/com/chiwawa/lionheart/common/constant/message/AttendanceErrorMessage.java
@@ -1,6 +1,0 @@
-package com.chiwawa.lionheart.common.constant.message;
-
-public class AttendanceErrorMessage {
-
-	public static final String NOT_EXIST_MEMBER_ATTENDANCE_DATA_ERROR_MESSAGE = "해당 유저(%s)의 출석체크 정보가 존재하지 않습니다";
-}

--- a/lionheart-common/src/main/java/com/chiwawa/lionheart/common/exception/ErrorCode.java
+++ b/lionheart-common/src/main/java/com/chiwawa/lionheart/common/exception/ErrorCode.java
@@ -28,7 +28,6 @@ public enum ErrorCode {
 	NOT_FOUND_CHALLENGE_EXCEPTION("N004", "존재하지 않는 챌린지입니다."),
 	NOT_FOUND_ARTICLE_EXCEPTION("N005", "삭제되었거나 존재하지 않는 아티클입니다."),
 	NOT_FOUND_ARTICLE_IN_WEEK_AND_DAY_EXCEPTION("N006", "해당 주차 일차에 해당하는 아티클이 존재하지 않습니다."),
-	NOT_FOUND_MEMBER_ATTENDANCE_DATA_EXCEPTION("N007", "해당 유저의 출석체크 정보가 존재하지 않습니다"),
 
 	// Conflict Exception
 	CONFLICT_EXCEPTION("C001", "이미 존재합니다."),

--- a/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/article/Article.java
+++ b/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/article/Article.java
@@ -47,6 +47,7 @@ public class Article extends BaseEntity {
 	private String title;
 
 	@Column(name = "CATEGORY", length = 30)
+	@Enumerated(value = EnumType.STRING)
 	private Category category;
 
 	@Column(name = "MAIN_IMAGE_URL", nullable = false, length = 300)
@@ -59,10 +60,10 @@ public class Article extends BaseEntity {
 	private String author;
 
 	@Column(name = "WEEK")
-	private short week;
+	private Short week;
 
 	@Column(name = "DAY")
-	private short day;
+	private Short day;
 
 	@Column(name = "REQUIRED_TIME", nullable = false)
 	private short requiredTime;

--- a/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/Attendance.java
+++ b/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/Attendance.java
@@ -35,4 +35,10 @@ public class Attendance extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "MEMBER_ID", nullable = false)
 	private Member member;
+
+	public static Attendance newInstance(Member member) {
+		return Attendance.builder()
+			.member(member)
+			.build();
+	}
 }

--- a/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -8,6 +8,4 @@ import com.chiwawa.lionheart.domain.domain.member.Member;
 public interface ChallengeRepositoryCustom {
 
 	Optional<Challenge> findChallengeByMember(Member member);
-
-	void checkAttendance(Member member);
 }

--- a/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/repository/ChallengeRepositoryImpl.java
+++ b/lionheart-domain/src/main/java/com/chiwawa/lionheart/domain/domain/challenge/repository/ChallengeRepositoryImpl.java
@@ -22,13 +22,4 @@ public class ChallengeRepositoryImpl implements ChallengeRepositoryCustom {
 			.where(challenge.member.eq(member))
 			.fetchOne());
 	}
-
-	@Override
-	public void checkAttendance(Member member) {
-		queryFactory
-			.insert(challenge)
-			.columns(challenge.member)
-			.values(member).execute();
-
-	}
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #58

## 🔑 Key Changes

1. attendance 가 존재하지 않는 경우에 에러 처리가 되고 있어서 수정했습니다!
2. 새로운 엔티티 생성하는 방식이 다른 부분이 있어서 통일했어요!

## 📢 To Reviewers
- 아요쪽에서 테스트가 급해서 먼저 머지할게요! 코드리뷰 머지 이후에 달아주셔도 좋습니당!
