### PR TITLE
✨: feat 주차별 아티클 조회 시, 오늘의 아티클 여부 기능 추가 #63

### DIFF
--- a/lionheart-api/src/main/java/com/chiwawa/lionheart/api/controller/article/ArticleRetrieveController.java
+++ b/lionheart-api/src/main/java/com/chiwawa/lionheart/api/controller/article/ArticleRetrieveController.java
@@ -12,6 +12,7 @@ import com.chiwawa.lionheart.api.service.article.ArticleRetrieveService;
 import com.chiwawa.lionheart.api.service.article.dto.response.ArticleDetailResponse;
 import com.chiwawa.lionheart.api.service.article.dto.response.ArticleSummaryResponse;
 import com.chiwawa.lionheart.api.service.article.dto.response.TodayArticleResponse;
+import com.chiwawa.lionheart.api.service.article.dto.response.WeekArticleSummaryResponse;
 import com.chiwawa.lionheart.common.dto.ApiResponse;
 import com.chiwawa.lionheart.domain.domain.article.Category;
 
@@ -48,7 +49,7 @@ public class ArticleRetrieveController {
 	@Operation(summary = "[인증] 주차별 아티클 조회")
 	@Auth
 	@GetMapping("/article/week/{week}")
-	public ApiResponse<ArticleSummaryResponse> findArticlesOfWeek(
+	public ApiResponse<WeekArticleSummaryResponse> findArticlesOfWeek(
 		@MemberId final Long memberId,
 		@Parameter(description = "주차", required = true, example = "1") @PathVariable final short week) {
 		return ApiResponse.success(articleService.findArticlesByWeekAndMemberId(memberId, week));

--- a/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/dto/response/WeekArticleSummaryDto.java
+++ b/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/dto/response/WeekArticleSummaryDto.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class ArticleSummaryDto {
+public class WeekArticleSummaryDto {
 
 	@Schema(description = "아티클ID")
 	private Long articleId;
@@ -38,18 +38,22 @@ public class ArticleSummaryDto {
 	@Schema(description = "북마크 여부")
 	private Boolean isMarked;
 
+	@Schema(description = "오늘의 아티클 여부")
+	private Boolean isTodayArticle;
+
 	@Schema(description = "아티클 태그정보")
 	private List<String> tags;
 
-	public static ArticleSummaryDto of(Article article, ArticleContent content, List<String> tag,
-		boolean isMarked) {
-		return ArticleSummaryDto.builder()
+	public static WeekArticleSummaryDto of(Article article, ArticleContent content, List<String> tag,
+		boolean isMarked, boolean isTodayArticle) {
+		return WeekArticleSummaryDto.builder()
 			.articleId(article.getId())
 			.title(article.getTitle())
 			.mainImageUrl(article.getMainImageUrl())
 			.requiredTime(article.getRequiredTime())
 			.firstBodyContent(content.getContent())
 			.isMarked(isMarked)
+			.isTodayArticle(isTodayArticle)
 			.tags(tag)
 			.build();
 	}

--- a/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/dto/response/WeekArticleSummaryResponse.java
+++ b/lionheart-api/src/main/java/com/chiwawa/lionheart/api/service/article/dto/response/WeekArticleSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.chiwawa.lionheart.api.service.article.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class WeekArticleSummaryResponse {
+
+	@Schema(description = "아티클 요약 정보")
+	private List<WeekArticleSummaryDto> weekArticles;
+
+	public static WeekArticleSummaryResponse of(List<WeekArticleSummaryDto> weekArticles) {
+		return WeekArticleSummaryResponse
+			.builder()
+			.weekArticles(weekArticles)
+			.build();
+	}
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #63 

## 🔑 Key Changes

1. 내용
    - Member의 WeekAndDay를 구하고 입력받은 week에 포함된 articles 중 week와 day가 Member WeekAndDay와 같다면 isTodayArticle을 true, 아니라면 false로 초기화하여 객체를 생성 후 response하도록 로직을 구성하였습니다

## 📢 To Reviewers
-
